### PR TITLE
Delete .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@sap:registry=https://npm.sap.com


### PR DESCRIPTION
The @sap scoped registry should now point to registry.npmjs.org rather than npm.sap.com.  Please see https://jam4.sapjam.com/feed/item/eOtNGT1RSxVzknBtpSy2My for full details on the migration.  npm.sap.com will not be updated going forward for the CDS library