### PR TITLE
cat-services.cds: Use "type of" to use "Books:id"

### DIFF
--- a/bookshop/srv/cat-service.cds
+++ b/bookshop/srv/cat-service.cds
@@ -6,5 +6,5 @@ service CatalogService @(path:'/browse') {
   } excluding { createdBy, modifiedBy };
 
   @requires_: 'authenticated-user'
-  action submitOrder (book : type of Books:ID, amount: Integer);
+  action submitOrder (book : Books:ID, amount: Integer);
 }

--- a/bookshop/srv/cat-service.cds
+++ b/bookshop/srv/cat-service.cds
@@ -6,5 +6,5 @@ service CatalogService @(path:'/browse') {
   } excluding { createdBy, modifiedBy };
 
   @requires_: 'authenticated-user'
-  action submitOrder (book : Books.ID, amount: Integer);
+  action submitOrder (book : type of Books:ID, amount: Integer);
 }


### PR DESCRIPTION
The syntax `Books.id` (dot) is deprecated and is warned about in the latest
CDS releases.  It should be replaced by either `Books:id` (colon, supported
since cds-compiler v1.41.0) or `type of Books:id` (tested with cds-compiler
v1.20.0 from November 2019).