### PR TITLE
make tests more robust

### DIFF
--- a/test/cds.ql.test.js
+++ b/test/cds.ql.test.js
@@ -1,5 +1,5 @@
+const { expect } = require('../test')
 const cds = require('@sap/cds/lib')
-const { expect } = cds.test
 const CQL = ([cql]) => cds.parse.cql(cql)
 const Foo = { name: 'Foo' }
 const Books = { name: 'capire.bookshop.Books' }

--- a/test/consuming-services.test.js
+++ b/test/consuming-services.test.js
@@ -1,7 +1,7 @@
-const cds = require('@sap/cds/lib')
-const { expect } = cds.test (
+const { expect } = require('../test') .run (
   'serve', 'AdminService', '--from', '@capire/bookshop,@capire/common', '--in-memory'
-).in(__dirname)
+)
+const cds = require('@sap/cds/lib')
 
 describe('Consuming Services locally', () => {
   //

--- a/test/custom-handlers.test.js
+++ b/test/custom-handlers.test.js
@@ -1,5 +1,5 @@
+const { GET, POST, expect } = require('../test') .run ('bookshop')
 const cds = require('@sap/cds/lib'); cds.User = cds.User.Privileged // skip auth
-const { GET, POST, expect } = cds.test('bookshop').in(__dirname,'..')
 
 describe('Custom Handlers', () => {
 

--- a/test/hello-world.test.js
+++ b/test/hello-world.test.js
@@ -1,5 +1,4 @@
-const cds = require('@sap/cds/lib')
-const { GET, expect } = cds.test('serve','hello/world.cds').in(__dirname,'..')
+const { GET, expect } = require('../test') .run ('serve','hello/world.cds')
 
 describe('Hello world!', () => {
 

--- a/test/hierarchical-data.test.js
+++ b/test/hierarchical-data.test.js
@@ -1,6 +1,5 @@
-const cwd = process.cwd(); process.chdir (__dirname) //> only for internal CI/CD@SAP
+const {expect} = require('../test')
 const cds = require('@sap/cds/lib')
-const {expect} = cds.test
 
 // monkey patching older releases:
 if (!cds.compile.cdl) cds.compile.cdl = cds.parse
@@ -24,8 +23,6 @@ describe('Hierarchical Data', ()=>{
 		expect (cds.db) .to.exist
     expect (cds.db.model) .to.exist
 	})
-
-	after(()=> process.chdir(cwd))
 
 	it ('supports deeply nested inserts', ()=> INSERT.into (Cats,
     { ID:100, name:'Some Cats...', children:[

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,6 @@
+
+const test = require('@sap/cds/lib/utils/tests').in(__dirname,'..')
+module.exports = Object.assign(test,{run:test})
+
+// REVISIT: With upcoming release of @sap/cds this should become:
+// module.exports = require('@sap/cds/tests').in(__dirname,'..')

--- a/test/localized-data.test.js
+++ b/test/localized-data.test.js
@@ -1,5 +1,5 @@
+const { GET, expect } = require('../test') .run ('serve', 'test/localized-data.cds', '--in-memory')
 const cds = require('@sap/cds/lib'); cds.User = cds.User.Privileged // skip auth
-const { GET, expect } = cds.test ('serve', __dirname+'/localized-data.cds', '--in-memory')
 
 describe('Localized Data', () => {
 

--- a/test/messaging.test.js
+++ b/test/messaging.test.js
@@ -1,12 +1,9 @@
+const { expect } = require('../test')
 const cds = require('@sap/cds/lib')
-const cwd = process.cwd(); process.chdir (__dirname) //> only for internal CI/CD@SAP
-const {expect} = cds.test
 const _model = '@capire/reviews'
 cds.User = cds.User.Privileged // hard core monkey patch
 
 describe('Messaging', ()=>{
-
-    after(()=> process.chdir(cwd))
 
     it ('should bootstrap sqlite in-memory db', async()=>{
         const db = await cds.deploy (_model) .to ('sqlite::memory:')

--- a/test/odata.test.js
+++ b/test/odata.test.js
@@ -1,7 +1,8 @@
+const { GET, expect } = require('../test') .run ('bookshop')
 const cds = require('@sap/cds/lib'); cds.User = cds.User.Privileged // skip auth
-const { GET, expect } = cds.test('bookshop').in(__dirname,'..')
 
 describe('OData Protocol', () => {
+
 
   it('serves $metadata documents in v4', async () => {
     const { headers, status, data } = await GET `/browse/$metadata`


### PR DESCRIPTION
This worked:
```js
const cds = require('@sap/cds')
const { GET, expect } = cds.test(...).in(__dirname)
//> expects all be run in cwd = __dirname
```

This failed occasionally:
```js
const cds = require('@sap/cds')
cds.env //> or doing something with cds, which in turn used cds.env
const { GET, expect } = cds.test(...).in(__dirname)
//> expects all be run in cwd = __dirname, but cds.env was pinned to process.cwd() before
```
