### PR TITLE
Support NODE 14

### DIFF
--- a/shared/dev-env/package.json
+++ b/shared/dev-env/package.json
@@ -5,7 +5,7 @@
     "@sap/cds": "^3.17.4"
   },
   "devDependencies": {
-    "sqlite3": "^4.0.7"
+    "sqlite3": "5.0.0"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
When trying to execute the exercise in this branch:
https://github.com/SAP-samples/cloud-cap-samples/tree/CAA265-node-initial
On machine with NODE 14 it fails.
When bumping sqlite3 to 5.0.0 it works OK.

Regards,
Offer.