### PR TITLE
Replace @assert.enum with @assert.range

### DIFF
--- a/reviews/srv/reviews-service.cds
+++ b/reviews/srv/reviews-service.cds
@@ -17,7 +17,7 @@ service ReviewsService {
   annotate Reviews with {
     subject  @mandatory;
     title    @mandatory;
-    rating   @assert.enum;
+    rating   @assert.range;
   }
 
 }


### PR DESCRIPTION
@assert.enum has been deprecated since April 2020: https://cap.cloud.sap/docs/releases/apr20#value-range-annotations-for-odata
@assert.range is the correct annotation to use: https://cap.cloud.sap/docs/guides/generic#assertrange-check-constraints