### PR TITLE
Fix broken translation UI

### DIFF
--- a/fiori/app/admin/fiori-service.cds
+++ b/fiori/app/admin/fiori-service.cds
@@ -70,7 +70,7 @@ annotate AdminService.Authors with @(
 annotate sap.capire.bookshop.Books with @fiori.draft.enabled;
 annotate AdminService.Books with @odata.draft.enabled;
 
-annotate AdminService.Books_texts with @(
+annotate AdminService.Books.texts with @(
 	UI: {
 		Identification: [{Value:title}],
 		SelectionFields: [ locale, title ],
@@ -83,7 +83,7 @@ annotate AdminService.Books_texts with @(
 );
 
 // Add Value Help for Locales
-annotate AdminService.Books_texts {
+annotate AdminService.Books.texts {
 	locale @ValueList:{entity:'Languages',type:#fixed}
 }
 // In addition we need to expose Languages through AdminService

--- a/fiori/package.json
+++ b/fiori/package.json
@@ -6,7 +6,7 @@
     "@capire/reviews": "*",
     "@capire/orders": "*",
     "@capire/common": "*",
-    "@sap/cds": ">=4",
+    "@sap/cds": "^5",
     "express": "^4.17.1",
     "passport": "^0.4.1"
   },

--- a/orders/package.json
+++ b/orders/package.json
@@ -2,6 +2,6 @@
   "name": "@capire/orders",
   "version": "1.0.0",
   "dependencies": {
-    "@sap/cds": ">=4.3.0"
+    "@sap/cds": "^5"
   }
 }

--- a/reviews/package.json
+++ b/reviews/package.json
@@ -7,7 +7,7 @@
     "index.cds"
   ],
   "dependencies": {
-    "@sap/cds": ">=4",
+    "@sap/cds": "^5",
     "express": "^4.17.1"
   },
   "scripts": {


### PR DESCRIPTION
Use `Books.texts` instead of `_texts`, requiring sap/cds 5