### PR TITLE
ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ default-env.json
 packages/messageBox
 reviews/msg-box
 reviews/db/test.db
+package-lock.json


### PR DESCRIPTION
running an `npm install` results in changes not staged for commit due to the created package-lock.json.