### PR TITLE
Draft for localized: expose Books.texts well

### DIFF
--- a/fiori/app/admin/fiori-service.cds
+++ b/fiori/app/admin/fiori-service.cds
@@ -1,4 +1,4 @@
-using { AdminService } from '../../db/schema';
+using { AdminService, sap.capire.bookshop } from '../../db/schema';
 
 ////////////////////////////////////////////////////////////////////////////
 //
@@ -86,8 +86,9 @@ annotate AdminService.Books.texts with @(
 annotate AdminService.Books.texts {
 	locale @ValueList:{entity:'Languages',type:#fixed}
 }
-// In addition we need to expose Languages through AdminService
+// In addition we need to expose Languages and Books.texts through AdminService
 using { sap } from '@sap/cds/common';
 extend service AdminService {
 	entity Languages as projection on sap.common.Languages;
+	entity Books.texts as projection on bookshop.Books.texts;
 }


### PR DESCRIPTION
`Books.texts` must be explicitly exposed in order to be drafted