### PR TITLE
How to run embedded OrderService?

### DIFF
--- a/fiori/package.json
+++ b/fiori/package.json
@@ -26,7 +26,7 @@
         "kind": "odata",
         "model": "@capire/reviews"
       },
-      "OrdersService": {
+      "--> OrdersService": {
         "kind": "odata",
         "model": "@capire/orders"
       },


### PR DESCRIPTION
cds deploy excludes its definitions if `OrdersService` is marked
as external, leading to exceptions in the UI.

How would we tell it to include them in the embedded case?