### PR TITLE
Fix UI warnings

### DIFF
--- a/fiori/app/admin/fiori-service.cds
+++ b/fiori/app/admin/fiori-service.cds
@@ -1,4 +1,5 @@
 using { AdminService, sap.capire.bookshop } from '../../db/schema';
+using from '../common'; // to help UI linter get the complete annotations
 
 ////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
These were caused by the UI check not being aware of the parallel
`common.cds` file.