### PR TITLE
Removing workaround for glitch in drafts

### DIFF
--- a/fiori/app/admin/fiori-service.cds
+++ b/fiori/app/admin/fiori-service.cds
@@ -87,9 +87,8 @@ annotate AdminService.Books.texts with @(
 annotate AdminService.Books.texts {
 	locale @ValueList:{entity:'Languages',type:#fixed}
 }
-// In addition we need to expose Languages and Books.texts through AdminService
+// In addition we need to expose Languages through AdminService as a target for ValueList
 using { sap } from '@sap/cds/common';
 extend service AdminService {
-	entity Languages as projection on sap.common.Languages;
-	entity Books.texts as projection on bookshop.Books.texts;
+	@readonly entity Languages as projection on sap.common.Languages;
 }

--- a/fiori/app/admin/fiori-service.cds
+++ b/fiori/app/admin/fiori-service.cds
@@ -1,4 +1,4 @@
-using { AdminService, sap.capire.bookshop } from '../../db/schema';
+using { AdminService } from '../../db/schema';
 using from '../common'; // to help UI linter get the complete annotations
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Reverting https://github.com/SAP-samples/cloud-cap-samples/pull/251
Root cause is a glitch in the runtime's draft handling

**DONT'T MERGE** before fix becomes available with 5.3.1