### PR TITLE
Increase test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "jest": {
     "testEnvironment": "node",
+    "testTimeout": 20000,
     "testMatch": [
       "**/*.test.js"
     ]


### PR DESCRIPTION
At least on slower machines or when file system caches are not filled,
the default 5000 ms are not enough for the tests to finish.