### PR TITLE
Add multiple books as one JSON batch request

### DIFF
--- a/bookshop/db/data/sap.capire.bookshop-Authors.csv
+++ b/bookshop/db/data/sap.capire.bookshop-Authors.csv
@@ -1,5 +1,6 @@
 ID;name;dateOfBirth;placeOfBirth;dateOfDeath;placeOfDeath
 101;Emily Brontë;1818-07-30;Thornton, Yorkshire;1848-12-19;Haworth, Yorkshire
 107;Charlotte Brontë;1818-04-21;Thornton, Yorkshire;1855-03-31;Haworth, Yorkshire
+123;Stephen King;1947-09-21;Portland, Maine;null;null
 150;Edgar Allen Poe;1809-01-19;Boston, Massachusetts;1849-10-07;Baltimore, Maryland
 170;Richard Carpenter;1929-08-14;King’s Lynn, Norfolk;2012-02-26;Hertfordshire, England

--- a/bookshop/test/requests.http
+++ b/bookshop/test/requests.http
@@ -50,7 +50,8 @@ Authorization: Basic alice:
 }
 
 ### ------------------------------------------------------------------------
-# Create multiple books in one batch request
+# Create multiple books in one JSON batch request
+# JSON batch request are only available in the NodeJS stack
 POST {{server}}/admin/$batch
 Content-Type: application/json;IEEE754Compatible=true
 Authorization: Basic alice:

--- a/bookshop/test/requests.http
+++ b/bookshop/test/requests.http
@@ -49,6 +49,88 @@ Authorization: Basic alice:
   "currency": { "code": "USD" }
 }
 
+### ------------------------------------------------------------------------
+# Create multiple books in one batch request
+POST {{server}}/admin/$batch
+Content-Type: application/json;IEEE754Compatible=true
+Authorization: Basic alice:
+
+{
+  "requests": [
+    {
+      "id": "1",
+      "method": "POST",
+      "url": "Books",
+      "headers": {
+        "content-type": "application/json"
+      },
+      "body": {
+        "ID": 191,
+        "title": "The Dark Tower",
+        "author": {
+          "ID": 123
+        },
+        "genre": {
+          "ID": 13
+        },
+        "stock": 5,
+        "price": "9.99",
+        "currency": {
+          "code": "USD"
+        }
+      }
+    },
+    {
+      "id": "2",
+      "method": "POST",
+      "url": "Books",
+      "body": {
+        "ID": 192,
+        "title": "The Dark Tower II",
+        "author": {
+          "ID": 123
+        },
+        "genre": {
+          "ID": 13
+        },
+        "stock": 5,
+        "price": "9.99",
+        "currency": {
+          "code": "USD"
+        }
+      },
+      "headers": {
+        "content-type": "application/json"
+      }
+    },
+    {
+      "id": "3",
+      "method": "POST",
+      "url": "Books",
+      "body": {
+        "ID": 193,
+        "title": "The Dark Tower III",
+        "author": {
+          "ID": 123
+        },
+        "genre": {
+          "ID": 13
+        },
+        "stock": 7,
+        "price": "9.99",
+        "currency": {
+          "code": "USD"
+        }
+      },
+      "headers": {
+        "content-type": "application/json"
+      }
+    }
+  ]
+}
+
+
+
 
 ### ------------------------------------------------------------------------
 # Put image to books


### PR DESCRIPTION
For me it was not obvious how I could POST multiple books as part of one request.
I got hinted to the OData specification where I was able to find some information on this.
I would suggest we add a sample $batch request to our prominent bookshop sample, so that
it is easier for beginners to understand this concept.