### PR TITLE
Demo for Semantic Navigation using the local Fiori Launchpad

### DIFF
--- a/bookshop/srv/cat-service.cds
+++ b/bookshop/srv/cat-service.cds
@@ -1,16 +1,34 @@
-using { sap.capire.bookshop as my } from '../db/schema';
-service CatalogService @(path:'/browse') {
+using {sap.capire.bookshop as my} from '../db/schema';
 
-  /** For displaying lists of Books */
-  @readonly entity ListOfBooks as projection on Books
-  excluding { descr };
+service CatalogService @(path : '/browse') {
 
-  /** For display in details pages */
-  @readonly entity Books as projection on my.Books { *,
-    author.name as author
-  } excluding { createdBy, modifiedBy };
+  /**
+   * For displaying lists of Books
+   */
+  @readonly
+  entity ListOfBooks as projection on Books excluding {
+    descr
+  };
 
-  @requires: 'authenticated-user'
-  action submitOrder ( book: Books:ID, quantity: Integer ) returns { stock: Integer };
-  event OrderedBook : { book: Books:ID; quantity: Integer; buyer: String };
+  /**
+   * For display in details pages
+   */
+  @readonly
+  entity Books       as projection on my.Books {
+    * , author.name as author
+  } excluding {
+    createdBy,
+    modifiedBy
+  };
+
+  @requires : 'authenticated-user'
+  action submitOrder(book : Books:ID, quantity : Integer) returns {
+    stock : Integer
+  };
+
+  event OrderedBook : {
+    book     : Books:ID;
+    quantity : Integer;
+    buyer    : String
+  };
 }

--- a/bookshop/srv/cat-service.cds
+++ b/bookshop/srv/cat-service.cds
@@ -15,8 +15,14 @@ service CatalogService @(path : '/browse') {
    */
   @readonly
   entity Books       as projection on my.Books {
-    * , author.name as author
+    * , author.name as authorName
   } excluding {
+    createdBy,
+    modifiedBy
+  };
+
+  @readonly
+  entity Authors     as projection on my.Authors excluding {
     createdBy,
     modifiedBy
   };

--- a/bookshop/srv/cat-service.cds
+++ b/bookshop/srv/cat-service.cds
@@ -22,7 +22,9 @@ service CatalogService @(path : '/browse') {
   };
 
   @readonly
-  entity Authors     as projection on my.Authors excluding {
+  entity Authors     as projection on my.Authors {
+    * , books : redirected to Books
+  } excluding {
     createdBy,
     modifiedBy
   };

--- a/fiori/app/admin/webapp/manifest.json
+++ b/fiori/app/admin/webapp/manifest.json
@@ -73,6 +73,7 @@
                     "options": {
                         "settings" : {
                             "entitySet" : "Books",
+                            "initialLoad": true,
                             "navigation" : {
                                 "Books" : {
                                     "detail" : {

--- a/fiori/app/appconfig/fioriSandboxConfig.json
+++ b/fiori/app/appconfig/fioriSandboxConfig.json
@@ -14,7 +14,6 @@
               "tiles": [
                 {
                   "id": "BrowseBooks",
-                  "size": "1×1",
                   "tileType": "sap.ushell.ui.tile.StaticTile",
                   "properties": {
                     "title": "Browse Books",
@@ -23,7 +22,6 @@
                 },
                 {
                   "id": "BrowseAuthors",
-                  "size": "1×1",
                   "tileType": "sap.ushell.ui.tile.StaticTile",
                   "properties": {
                     "title": "Browse Authors",
@@ -41,7 +39,6 @@
               "tiles": [
                 {
                   "id": "ManageBooks",
-                  "size": "1×1",
                   "tileType": "sap.ushell.ui.tile.StaticTile",
                   "properties": {
                     "title": "Manage Books",
@@ -50,7 +47,6 @@
                 },
                 {
                   "id": "ManageOrders",
-                  "size": "1×1",
                   "tileType": "sap.ushell.ui.tile.StaticTile",
                   "properties": {
                     "title": "Manage Orders",
@@ -77,8 +73,12 @@
               "action": "display",
               "title": "Browse Books",
               "signature": {
-                "parameters": {},
-                "additionalParameters": "allowed"
+                "parameters": {
+                  "Books.author.ID":{
+                    "renameTo": "ID"                    
+                  }
+                },
+                "additionalParameters": "ignored"
               },
               "resolutionResult": {
                 "applicationType": "SAPUI5",

--- a/fiori/app/appconfig/fioriSandboxConfig.json
+++ b/fiori/app/appconfig/fioriSandboxConfig.json
@@ -1,0 +1,135 @@
+{
+  "services": {
+    "LaunchPage": {
+      "adapter": {
+        "config": {
+          "catalogs": [],
+          "groups": [
+            {
+              "id": "Bookshop",
+              "title": "Bookshop",
+              "isPreset": true,
+              "isVisible": true,
+              "isGroupLocked": false,
+              "tiles": [
+                {
+                  "id": "BrowseBooks",
+                  "size": "1×1",
+                  "tileType": "sap.ushell.ui.tile.StaticTile",
+                  "properties": {
+                    "title": "Browse Books",
+                    "targetURL": "#Books-display"
+                  }
+                },
+                {
+                  "id": "BrowseAuthors",
+                  "size": "1×1",
+                  "tileType": "sap.ushell.ui.tile.StaticTile",
+                  "properties": {
+                    "title": "Browse Authors",
+                    "targetURL": "#Authors-display"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "Administration",
+              "title": "Administration",
+              "isPreset": true,
+              "isVisible": true,
+              "isGroupLocked": false,
+              "tiles": [
+                {
+                  "id": "ManageBooks",
+                  "size": "1×1",
+                  "tileType": "sap.ushell.ui.tile.StaticTile",
+                  "properties": {
+                    "title": "Manage Books",
+                    "targetURL": "#Books-manage"
+                  }
+                },
+                {
+                  "id": "ManageOrders",
+                  "size": "1×1",
+                  "tileType": "sap.ushell.ui.tile.StaticTile",
+                  "properties": {
+                    "title": "Manage Orders",
+                    "targetURL": "#Orders-manage"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "NavTargetResolution": {
+      "config": {
+        "enableClientSideTargetResolution": true
+      }
+    },
+    "ClientSideTargetResolution": {
+      "adapter": {
+        "config": {
+          "inbounds": {
+            "BrowseBooks": {
+              "semanticObject": "Books",
+              "action": "display",
+              "title": "Browse Books",
+              "signature": {
+                "parameters": {},
+                "additionalParameters": "allowed"
+              },
+              "resolutionResult": {
+                "applicationType": "SAPUI5",
+                "additionalInformation": "SAPUI5.Component=bookshop",
+                "url": "/browse/webapp"
+              }
+            },
+            "BrowseAuthors": {
+              "semanticObject": "Authors",
+              "action": "display",
+              "title": "Browse Authors",
+              "signature": {
+                "parameters": {},
+                "additionalParameters": "allowed"
+              },
+              "resolutionResult": {
+                "applicationType": "SAPUI5",
+                "additionalInformation": "SAPUI5.Component=authors",
+                "url": "/authors/webapp"
+              }
+            },
+            "ManageBooks": {
+              "semanticObject": "Books",
+              "action": "manage",
+              "title": "Manage Books",
+              "signature": {
+                "parameters": {},
+                "additionalParameters": "allowed"
+              },
+              "resolutionResult": {
+                "applicationType": "SAPUI5",
+                "additionalInformation": "SAPUI5.Component=admin",
+                "url": "/admin/webapp"
+              }
+            },
+            "ManageOrders": {
+              "semanticObject": "Orders",
+              "action": "manage",
+              "signature": {
+                "parameters": {},
+                "additionalParameters": "allowed"
+              },
+              "resolutionResult": {
+                "applicationType": "SAPUI5",
+                "additionalInformation": "SAPUI5.Component=orders",
+                "url": "/orders/webapp"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/fiori/app/appconfig/fioriSandboxConfig.json
+++ b/fiori/app/appconfig/fioriSandboxConfig.json
@@ -74,7 +74,10 @@
               "title": "Browse Books",
               "signature": {
                 "parameters": {
-                  "Books.author.ID":{
+                  "Books.ID": {
+                    "renameTo": "ID"                    
+                  },
+                  "Authors.books.ID": {
                     "renameTo": "ID"                    
                   }
                 },
@@ -91,8 +94,12 @@
               "action": "display",
               "title": "Browse Authors",
               "signature": {
-                "parameters": {},
-                "additionalParameters": "allowed"
+                "parameters": {
+                  "Books.author.ID":{
+                    "renameTo": "ID"
+                  }
+                },
+                "additionalParameters": "ignored"
               },
               "resolutionResult": {
                 "applicationType": "SAPUI5",

--- a/fiori/app/authors/fiori-service.cds
+++ b/fiori/app/authors/fiori-service.cds
@@ -28,19 +28,3 @@ annotate CatalogService.Authors with @(UI : {
         {Value : placeOfDeath},
     ]},
 });
-
-
-////////////////////////////////////////////////////////////////////////////
-//
-//	Authors List Page
-//
-annotate CatalogService.Authors with @(UI : {
-    SelectionFields : [
-        ID,
-        name,
-    ],
-    LineItem        : [
-        {Value : ID},
-        {Value : name},
-    ]
-}, );

--- a/fiori/app/authors/fiori-service.cds
+++ b/fiori/app/authors/fiori-service.cds
@@ -1,0 +1,46 @@
+using CatalogService from '@capire/bookshop';
+
+////////////////////////////////////////////////////////////////////////////
+//
+//	Authors Object Page
+//
+annotate CatalogService.Authors with @(UI : {
+    HeaderInfo        : {
+        TypeName       : 'Author',
+        TypeNamePlural : 'Authors',
+        Description    : {Value : name}
+    },
+    HeaderFacets      : [{
+        $Type  : 'UI.ReferenceFacet',
+        Label  : '{i18n>Description}',
+        Target : '@UI.FieldGroup#Descr'
+    }, ],
+    Facets            : [{
+        $Type  : 'UI.ReferenceFacet',
+        Label  : '{i18n>Details}',
+        Target : 'books/@UI.LineItem'
+    }, ],
+    FieldGroup #Descr : {Data : [
+        {Value : name},
+        {Value : dateOfBirth},
+        {Value : dateOfDeath},
+        {Value : placeOfBirth},
+        {Value : placeOfDeath},
+    ]},
+});
+
+
+////////////////////////////////////////////////////////////////////////////
+//
+//	Authors List Page
+//
+annotate CatalogService.Authors with @(UI : {
+    SelectionFields : [
+        ID,
+        name,
+    ],
+    LineItem        : [
+        {Value : ID},
+        {Value : name},
+    ]
+}, );

--- a/fiori/app/authors/webapp/Component.js
+++ b/fiori/app/authors/webapp/Component.js
@@ -1,0 +1,7 @@
+sap.ui.define(["sap/fe/core/AppComponent"], function (AppComponent) {
+  "use strict";
+  return AppComponent.extend("authors.Component", {
+    metadata: { manifest: "json" },
+  });
+});
+/* eslint no-undef:0 */

--- a/fiori/app/authors/webapp/i18n/i18n.properties
+++ b/fiori/app/authors/webapp/i18n/i18n.properties
@@ -1,0 +1,11 @@
+# This is the resource bundle of itelo
+# __ldi.translation.uuid=c3431418-9caf-11e8-98d0-529269fb1459
+
+# JCI app descriptor contains lower case TITLE
+appTitle=Bookshop Authors
+
+# JCI app descriptor contains lower case DESCRIPTION
+appSubTitle=Bookshop Authors
+
+# JCI app descriptor contains lower case DESCRIPTION
+appDescription=Bookshop Authors

--- a/fiori/app/authors/webapp/manifest.json
+++ b/fiori/app/authors/webapp/manifest.json
@@ -1,0 +1,106 @@
+{
+  "_version": "1.8.0",
+  "sap.app": {
+    "id": "authors",
+    "type": "application",
+    "title": "Browse Authors",
+    "description": "Sample Application",
+    "i18n": "i18n/i18n.properties",
+    "dataSources": {
+      "CatalogService": {
+        "uri": "/browse/",
+        "type": "OData",
+        "settings": {
+          "odataVersion": "4.0"
+        }
+      }
+    },
+    "-sourceTemplate": {
+      "id": "ui5template.basicSAPUI5ApplicationProject",
+      "-id": "ui5template.smartTemplate",
+      "-version": "1.40.12"
+    }
+  },
+  "sap.ui5": {
+    "dependencies": {
+      "libs": {
+        "sap.fe.templates": {}
+      }
+    },
+    "models": {
+      "i18n": {
+        "type": "sap.ui.model.resource.ResourceModel",
+        "uri": "i18n/i18n.properties"
+      },
+      "": {
+        "dataSource": "CatalogService",
+        "settings": {
+          "synchronizationMode": "None",
+          "operationMode": "Server",
+          "autoExpandSelect": true,
+          "earlyRequests": true,
+          "groupProperties": {
+            "default": {
+              "submit": "Auto"
+            }
+          }
+        }
+      }
+    },
+    "routing": {
+      "routes": [
+        {
+          "pattern": ":?query:",
+          "name": "AuthorsList",
+          "target": "AuthorsList"
+        },
+        {
+          "pattern": "Authors({key}):?query:",
+          "name": "AuthorsDetails",
+          "target": "AuthorsDetails"
+        }
+      ],
+      "targets": {
+        "AuthorsList": {
+          "type": "Component",
+          "id": "AuthorsList",
+          "name": "sap.fe.templates.ListReport",
+          "options": {
+            "settings": {
+              "entitySet": "Authors",
+              "navigation": {
+                "Authors": {
+                  "detail": {
+                    "route": "AuthorsDetails"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "AuthorsDetails": {
+          "type": "Component",
+          "id": "AuthorsDetailsList",
+          "name": "sap.fe.templates.ObjectPage",
+          "options": {
+            "settings": {
+              "entitySet": "Authors"
+            }
+          }
+        }
+      }
+    },
+    "contentDensities": {
+      "compact": true,
+      "cozy": true
+    }
+  },
+  "sap.ui": {
+    "technology": "UI5",
+    "fullWidth": false
+  },
+  "sap.fiori": {
+    "registrationIds": [],
+    "archeType": "transactional"
+  }
+}

--- a/fiori/app/authors/webapp/manifest.json
+++ b/fiori/app/authors/webapp/manifest.json
@@ -68,6 +68,7 @@
           "options": {
             "settings": {
               "entitySet": "Authors",
+              "initialLoad": true,
               "navigation": {
                 "Authors": {
                   "detail": {

--- a/fiori/app/authors/webapp/manifest.json
+++ b/fiori/app/authors/webapp/manifest.json
@@ -1,11 +1,14 @@
 {
-  "_version": "1.8.0",
+  "_version": "1.28.0",
   "sap.app": {
     "id": "authors",
     "type": "application",
     "title": "Browse Authors",
     "description": "Sample Application",
     "i18n": "i18n/i18n.properties",
+    "applicationVersion": {
+      "version": "1.0.0"
+    },
     "dataSources": {
       "CatalogService": {
         "uri": "/browse/",
@@ -15,14 +18,40 @@
         }
       }
     },
-    "-sourceTemplate": {
+    "sourceTemplate": {
       "id": "ui5template.basicSAPUI5ApplicationProject",
       "-id": "ui5template.smartTemplate",
-      "-version": "1.40.12"
+      "version": "1.40.12"
+    },
+    "crossNavigation": {
+      "inbounds": {
+        "intent1": {
+          "signature": {
+            "parameters": {
+              "Books.author.ID":{
+                "renameTo": "ID"
+              }
+            },
+            "additionalParameters": "ignored"
+          },
+          "semanticObject": "Authors",
+          "action": "display",
+          "title": "{{appTitle}}",
+          "info": "{{appInfo}}",
+          "subTitle": "{{appSubTitle}}",
+          "icon": "sap-icon://SAP-icons-TNT/user",
+          "indicatorDataSource": {
+            "dataSource": "CatalogService",
+            "path": "Authors/$count",
+            "refresh": 1800
+          }
+        }
+      }
     }
   },
   "sap.ui5": {
     "dependencies": {
+      "minUI5Version": "1.81.0",
       "libs": {
         "sap.fe.templates": {}
       }
@@ -98,7 +127,12 @@
   },
   "sap.ui": {
     "technology": "UI5",
-    "fullWidth": false
+    "fullWidth": false,
+    "deviceTypes":{
+      "desktop": true,
+      "tablet": true,
+      "phone": true
+    }
   },
   "sap.fiori": {
     "registrationIds": [],

--- a/fiori/app/browse/fiori-service.cds
+++ b/fiori/app/browse/fiori-service.cds
@@ -43,6 +43,7 @@ annotate CatalogService.Books with @(UI : {
     ],
     LineItem        : [
         {Value : title},
+        {Value : author.ID},
         {
             Value : authorName,
             Label : '{i18n>Author}'

--- a/fiori/app/browse/fiori-service.cds
+++ b/fiori/app/browse/fiori-service.cds
@@ -42,10 +42,12 @@ annotate CatalogService.Books with @(UI : {
         currency_code
     ],
     LineItem        : [
-        {Value : title},
-        {Value : author.ID},
         {
-            Value : authorName,
+            Value : ID,
+            Label : '{i18n>Title}'
+        },
+        {
+            Value : author.ID,
             Label : '{i18n>Author}'
         },
         {Value : genre.name},

--- a/fiori/app/browse/fiori-service.cds
+++ b/fiori/app/browse/fiori-service.cds
@@ -4,47 +4,54 @@ using CatalogService from '@capire/bookshop';
 //
 //	Books Object Page
 //
-annotate CatalogService.Books with @(
-	UI: {
-		HeaderInfo: {
-			TypeName: 'Book',
-			TypeNamePlural: 'Books',
-			Description: {Value: author}
-		},
-		HeaderFacets: [
-			{$Type: 'UI.ReferenceFacet', Label: '{i18n>Description}', Target: '@UI.FieldGroup#Descr'},
-		],
-		Facets: [
-			{$Type: 'UI.ReferenceFacet', Label: '{i18n>Details}', Target: '@UI.FieldGroup#Price'},
-		],
-		FieldGroup#Descr: {
-			Data: [
-				{Value: descr},
-			]
-		},
-		FieldGroup#Price: {
-			Data: [
-				{Value: price},
-				{Value: currency.symbol, Label: '{i18n>Currency}'},
-			]
-		},
-	}
-);
+annotate CatalogService.Books with @(UI : {
+    HeaderInfo        : {
+        TypeName       : 'Book',
+        TypeNamePlural : 'Books',
+        Description    : {Value : authorName}
+    },
+    HeaderFacets      : [{
+        $Type  : 'UI.ReferenceFacet',
+        Label  : '{i18n>Description}',
+        Target : '@UI.FieldGroup#Descr'
+    }, ],
+    Facets            : [{
+        $Type  : 'UI.ReferenceFacet',
+        Label  : '{i18n>Details}',
+        Target : '@UI.FieldGroup#Price'
+    }, ],
+    FieldGroup #Descr : {Data : [{Value : descr}, ]},
+    FieldGroup #Price : {Data : [
+        {Value : price},
+        {
+            Value : currency.symbol,
+            Label : '{i18n>Currency}'
+        },
+    ]},
+});
 
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Books Object Page
 //
-annotate CatalogService.Books with @(
-	UI: {
-		SelectionFields: [ ID, price, currency_code ],
-		LineItem: [
-			{Value: title},
-			{Value: author, Label:'{i18n>Author}'},
-			{Value: genre.name},
-			{Value: price},
-			{Value: currency.symbol, Label:' '},
-		]
-	},
-);
+annotate CatalogService.Books with @(UI : {
+    SelectionFields : [
+        ID,
+        price,
+        currency_code
+    ],
+    LineItem        : [
+        {Value : title},
+        {
+            Value : authorName,
+            Label : '{i18n>Author}'
+        },
+        {Value : genre.name},
+        {Value : price},
+        {
+            Value : currency.symbol,
+            Label : ' '
+        },
+    ]
+}, );

--- a/fiori/app/browse/webapp/manifest.json
+++ b/fiori/app/browse/webapp/manifest.json
@@ -68,6 +68,7 @@
           "options": {
             "settings": {
               "entitySet": "Books",
+              "initialLoad": true,
               "navigation": {
                 "Books": {
                   "detail": {

--- a/fiori/app/browse/webapp/manifest.json
+++ b/fiori/app/browse/webapp/manifest.json
@@ -1,11 +1,14 @@
 {
-  "_version": "1.8.0",
+  "_version": "1.28.0",
   "sap.app": {
     "id": "bookshop",
     "type": "application",
     "title": "Browse Books",
     "description": "Sample Application",
     "i18n": "i18n/i18n.properties",
+    "applicationVersion": {
+      "version": "1.0.0"
+    },
     "dataSources": {
       "CatalogService": {
         "uri": "/browse/",
@@ -15,14 +18,15 @@
         }
       }
     },
-    "-sourceTemplate": {
+    "sourceTemplate": {
       "id": "ui5template.basicSAPUI5ApplicationProject",
       "-id": "ui5template.smartTemplate",
-      "-version": "1.40.12"
+      "version": "1.40.12"
     }
   },
   "sap.ui5": {
     "dependencies": {
+      "minUI5Version": "1.81.0",
       "libs": {
         "sap.fe.templates": {}
       }
@@ -98,7 +102,12 @@
   },
   "sap.ui": {
     "technology": "UI5",
-    "fullWidth": false
+    "fullWidth": false,
+    "deviceTypes":{
+      "desktop": true,
+      "tablet": true,
+      "phone": true
+    }
   },
   "sap.fiori": {
     "registrationIds": [],

--- a/fiori/app/browse/webapp/manifest.json
+++ b/fiori/app/browse/webapp/manifest.json
@@ -22,6 +22,34 @@
       "id": "ui5template.basicSAPUI5ApplicationProject",
       "-id": "ui5template.smartTemplate",
       "version": "1.40.12"
+    },
+    "crossNavigation": {
+      "inbounds": {
+        "intent1": {
+          "signature": {
+            "parameters": {
+              "Books.ID":{
+                "renameTo": "ID"
+              },
+              "Authors.books.ID": {
+                "renameTo": "ID"                    
+              }
+            },
+            "additionalParameters": "ignored"
+          },
+          "semanticObject": "Books",
+          "action": "display",
+          "title": "{{appTitle}}",
+          "info": "{{appInfo}}",
+          "subTitle": "{{appSubTitle}}",
+          "icon": "sap-icon://course-book",
+          "indicatorDataSource": {
+            "dataSource": "CatalogService",
+            "path": "Books/$count",
+            "refresh": 1800
+          }
+        }
+      }
     }
   },
   "sap.ui5": {

--- a/fiori/app/common.cds
+++ b/fiori/app/common.cds
@@ -1,48 +1,54 @@
 /*
-	Common Annotations shared by all apps
+ Common Annotations shared by all apps
 */
 
-using { sap.capire.bookshop as my } from '@capire/bookshop';
-using { sap.common } from '@capire/common';
+using {sap.capire.bookshop as my} from '@capire/bookshop';
+using {sap.common} from '@capire/common';
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Books Lists
 //
 annotate my.Books with @(
-	Common.SemanticKey: [title],
-	UI: {
-		Identification: [{Value:title}],
-		SelectionFields: [ ID, author_ID, price, currency_code ],
-		LineItem: [
-			{Value: ID},
-			{Value: title},
-			{Value: author.name, Label:'{i18n>Author}'},
-			{Value: genre.name},
-			{Value: stock},
-			{Value: price},
-			{Value: currency.symbol, Label:' '},
-		]
-	}
+    Common.SemanticKey : [title],
+    UI                 : {
+        Identification  : [{Value : title}],
+        SelectionFields : [
+            ID,
+            author_ID,
+            price,
+            currency_code
+        ],
+        LineItem        : [
+            {Value : ID},
+            {Value : title},
+            {
+                Value : author.name,
+                Label : '{i18n>Author}'
+            },
+            {Value : genre.name},
+            {Value : stock},
+            {Value : price},
+            {
+                Value : currency.symbol,
+                Label : ' '
+            },
+        ]
+    }
 ) {
-	author @ValueList.entity:'Authors';
+    author @ValueList.entity : 'Authors';
 };
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Books Details
 //
-annotate my.Books with @(
-	UI: {
-		HeaderInfo: {
-			TypeName: '{i18n>Book}',
-			TypeNamePlural: '{i18n>Books}',
-			Title: {Value: title},
-			Description: {Value: author.name}
-		},
-	}
-);
-
+annotate my.Books with @(UI : {HeaderInfo : {
+    TypeName       : '{i18n>Book}',
+    TypeNamePlural : '{i18n>Books}',
+    Title          : {Value : title},
+    Description    : {Value : author.name}
+}, });
 
 
 ////////////////////////////////////////////////////////////////////////////
@@ -50,13 +56,19 @@ annotate my.Books with @(
 //	Books Elements
 //
 annotate my.Books with {
-	ID @title:'{i18n>ID}' @UI.HiddenFilter;
-	title @title:'{i18n>Title}';
-	genre  @title:'{i18n>Genre}'  @Common: { Text: genre.name,  TextArrangement: #TextOnly };
-	author @title:'{i18n>Author}' @Common: { Text: author.name, TextArrangement: #TextOnly };
-	price @title:'{i18n>Price}' @Measures.ISOCurrency: currency_code;
-	stock @title:'{i18n>Stock}';
-	descr @UI.MultiLineText;
+    ID     @title : '{i18n>ID}'  @UI.HiddenFilter;
+    title  @title : '{i18n>Title}';
+    genre  @title : '{i18n>Genre}'  @Common               : {
+        Text            : genre.name,
+        TextArrangement : #TextOnly
+    };
+    author @title : '{i18n>Author}'  @Common              : {
+        Text            : author.name,
+        TextArrangement : #TextOnly
+    };
+    price  @title : '{i18n>Price}'  @Measures.ISOCurrency : currency_code;
+    stock  @title : '{i18n>Stock}';
+    descr  @UI.MultiLineText;
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -64,42 +76,45 @@ annotate my.Books with {
 //	Genres List
 //
 annotate my.Genres with @(
-	Common.SemanticKey: [name],
-	UI: {
-		SelectionFields: [ name ],
-		LineItem:[
-			{Value: name},
-			{Value: parent.name, Label: 'Main Genre'},
-		],
-	}
+    Common.SemanticKey : [name],
+    UI                 : {
+        SelectionFields : [name],
+        LineItem        : [
+            {Value : name},
+            {
+                Value : parent.name,
+                Label : 'Main Genre'
+            },
+        ],
+    }
 );
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Genre Details
 //
-annotate my.Genres with @(
-	UI: {
-		Identification: [{Value:name}],
-		HeaderInfo: {
-			TypeName: '{i18n>Genre}',
-			TypeNamePlural: '{i18n>Genres}',
-			Title: {Value: name},
-			Description: {Value: ID}
-		},
-		Facets: [
-			{$Type: 'UI.ReferenceFacet', Label: '{i18n>SubGenres}', Target: 'children/@UI.LineItem'},
-		],
-	}
-);
+annotate my.Genres with @(UI : {
+    Identification : [{Value : name}],
+    HeaderInfo     : {
+        TypeName       : '{i18n>Genre}',
+        TypeNamePlural : '{i18n>Genres}',
+        Title          : {Value : name},
+        Description    : {Value : ID}
+    },
+    Facets         : [{
+        $Type  : 'UI.ReferenceFacet',
+        Label  : '{i18n>SubGenres}',
+        Target : 'children/@UI.LineItem'
+    }, ],
+});
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Genres Elements
 //
 annotate my.Genres with {
-	ID  @title: '{i18n>ID}';
-	name  @title: '{i18n>Genre}';
+    ID   @title : '{i18n>ID}';
+    name @title : '{i18n>Genre}';
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -107,38 +122,37 @@ annotate my.Genres with {
 //	Authors List
 //
 annotate my.Authors with @(
-	Common.SemanticKey: [name],
-	UI: {
-		Identification: [{Value:name}],
-		SelectionFields: [ name ],
-		LineItem:[
-			{Value: ID},
-			{Value: name},
-			{Value: dateOfBirth},
-			{Value: dateOfDeath},
-			{Value: placeOfBirth},
-			{Value: placeOfDeath},
-		],
-	}
+    Common.SemanticKey : [name],
+    UI                 : {
+        Identification  : [{Value : name}],
+        SelectionFields : [name],
+        LineItem        : [
+            {Value : ID},
+            {Value : name},
+            {Value : dateOfBirth},
+            {Value : dateOfDeath},
+            {Value : placeOfBirth},
+            {Value : placeOfDeath},
+        ],
+    }
 );
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Author Details
 //
-annotate my.Authors with @(
-	UI: {
-		HeaderInfo: {
-			TypeName: '{i18n>Author}',
-			TypeNamePlural: '{i18n>Authors}',
-			Title: {Value: name},
-			Description: {Value: dateOfBirth}
-		},
-		Facets: [
-			{$Type: 'UI.ReferenceFacet', Target: 'books/@UI.LineItem'},
-		],
-	}
-);
+annotate my.Authors with @(UI : {
+    HeaderInfo : {
+        TypeName       : '{i18n>Author}',
+        TypeNamePlural : '{i18n>Authors}',
+        Title          : {Value : name},
+        Description    : {Value : dateOfBirth}
+    },
+    Facets     : [{
+        $Type  : 'UI.ReferenceFacet',
+        Target : 'books/@UI.LineItem'
+    }, ],
+});
 
 
 ////////////////////////////////////////////////////////////////////////////
@@ -146,12 +160,12 @@ annotate my.Authors with @(
 //	Authors Elements
 //
 annotate my.Authors with {
-	ID @title:'{i18n>ID}' @UI.HiddenFilter;
-	name @title:'{i18n>Name}';
-	dateOfBirth @title:'{i18n>DateOfBirth}';
-	dateOfDeath @title:'{i18n>DateOfDeath}';
-	placeOfBirth @title:'{i18n>PlaceOfBirth}';
-	placeOfDeath @title:'{i18n>PlaceOfDeath}';
+    ID           @title : '{i18n>ID}'  @UI.HiddenFilter;
+    name         @title : '{i18n>Name}';
+    dateOfBirth  @title : '{i18n>DateOfBirth}';
+    dateOfDeath  @title : '{i18n>DateOfDeath}';
+    placeOfBirth @title : '{i18n>PlaceOfBirth}';
+    placeOfDeath @title : '{i18n>PlaceOfDeath}';
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -159,99 +173,105 @@ annotate my.Authors with {
 //	Languages List
 //
 annotate common.Languages with @(
-	Common.SemanticKey: [code],
-	Identification: [{Value:code}],
-	UI: {
-		SelectionFields: [ name, descr ],
-		LineItem:[
-			{Value: code},
-			{Value: name},
-		],
-	}
+    Common.SemanticKey : [code],
+    Identification     : [{Value : code}],
+    UI                 : {
+        SelectionFields : [
+            name,
+            descr
+        ],
+        LineItem        : [
+            {Value : code},
+            {Value : name},
+        ],
+    }
 );
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Language Details
 //
-annotate common.Languages with @(
-	UI: {
-		HeaderInfo: {
-			TypeName: '{i18n>Language}',
-			TypeNamePlural: '{i18n>Languages}',
-			Title: {Value: name},
-			Description: {Value: descr}
-		},
-		Facets: [
-			{$Type: 'UI.ReferenceFacet', Label: '{i18n>Details}', Target: '@UI.FieldGroup#Details'},
-		],
-		FieldGroup#Details: {
-			Data: [
-				{Value: code},
-				{Value: name},
-				{Value: descr}
-			]
-		},
-	}
-);
+annotate common.Languages with @(UI : {
+    HeaderInfo          : {
+        TypeName       : '{i18n>Language}',
+        TypeNamePlural : '{i18n>Languages}',
+        Title          : {Value : name},
+        Description    : {Value : descr}
+    },
+    Facets              : [{
+        $Type  : 'UI.ReferenceFacet',
+        Label  : '{i18n>Details}',
+        Target : '@UI.FieldGroup#Details'
+    }, ],
+    FieldGroup #Details : {Data : [
+        {Value : code},
+        {Value : name},
+        {Value : descr}
+    ]},
+});
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Currencies List
 //
 annotate common.Currencies with @(
-	Common.SemanticKey: [code],
-	Identification: [{Value:code}],
-	UI: {
-		SelectionFields: [ name, descr ],
-		LineItem:[
-			{Value: descr},
-			{Value: symbol},
-			{Value: code},
-		],
-	}
+    Common.SemanticKey : [code],
+    Identification     : [{Value : code}],
+    UI                 : {
+        SelectionFields : [
+            name,
+            descr
+        ],
+        LineItem        : [
+            {Value : descr},
+            {Value : symbol},
+            {Value : code},
+        ],
+    }
 );
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Currency Details
 //
-annotate common.Currencies with @(
-	UI: {
-		HeaderInfo: {
-			TypeName: '{i18n>Currency}',
-			TypeNamePlural: '{i18n>Currencies}',
-			Title: {Value: descr},
-			Description: {Value: code}
-		},
-		Facets: [
-			{$Type: 'UI.ReferenceFacet', Label: '{i18n>Details}', Target: '@UI.FieldGroup#Details'},
-			{$Type: 'UI.ReferenceFacet', Label: '{i18n>Extended}', Target: '@UI.FieldGroup#Extended'},
-		],
-		FieldGroup#Details: {
-			Data: [
-				{Value: name},
-				{Value: symbol},
-				{Value: code},
-				{Value: descr}
-			]
-		},
-		FieldGroup#Extended: {
-			Data: [
-				{Value: numcode},
-				{Value: minor},
-				{Value: exponent}
-			]
-		},
-	}
-);
+annotate common.Currencies with @(UI : {
+    HeaderInfo           : {
+        TypeName       : '{i18n>Currency}',
+        TypeNamePlural : '{i18n>Currencies}',
+        Title          : {Value : descr},
+        Description    : {Value : code}
+    },
+    Facets               : [
+        {
+            $Type  : 'UI.ReferenceFacet',
+            Label  : '{i18n>Details}',
+            Target : '@UI.FieldGroup#Details'
+        },
+        {
+            $Type  : 'UI.ReferenceFacet',
+            Label  : '{i18n>Extended}',
+            Target : '@UI.FieldGroup#Extended'
+        },
+    ],
+    FieldGroup #Details  : {Data : [
+        {Value : name},
+        {Value : symbol},
+        {Value : code},
+        {Value : descr}
+    ]},
+    FieldGroup #Extended : {Data : [
+        {Value : numcode},
+        {Value : minor},
+        {Value : exponent}
+    ]},
+});
 
 ////////////////////////////////////////////////////////////////////////////
 //
 //	Currencies Elements
 //
 annotate common.Currencies with {
-	numcode @title:'{i18n>NumCode}';
-	minor @title:'{i18n>MinorUnit}';
-	exponent @title:'{i18n>Exponent}';
+    numcode  @title : '{i18n>NumCode}';
+    minor    @title : '{i18n>MinorUnit}';
+    exponent @title : '{i18n>Exponent}';
 }

--- a/fiori/app/common.cds
+++ b/fiori/app/common.cds
@@ -10,7 +10,7 @@ using {sap.common} from '@capire/common';
 //	Books Lists
 //
 annotate my.Books with @(
-    Common.SemanticKey : [title],
+    Common.SemanticKey : [ID],
     UI                 : {
         Identification  : [{Value : title}],
         SelectionFields : [
@@ -36,7 +36,8 @@ annotate my.Books with @(
         ]
     }
 ) {
-    author @ValueList.entity : 'Authors';
+    title  @Common.SemanticObject : 'Books';
+    author @ValueList.entity      : 'Authors';
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -122,7 +123,7 @@ annotate my.Genres with {
 //	Authors List
 //
 annotate my.Authors with @(
-    Common.SemanticKey : [name],
+    Common.SemanticKey : [ID],
     UI                 : {
         Identification  : [{Value : name}],
         SelectionFields : [name],
@@ -135,7 +136,9 @@ annotate my.Authors with @(
             {Value : placeOfDeath},
         ],
     }
-);
+) {
+    name @Common.SemanticObject : 'Authors';
+};
 
 ////////////////////////////////////////////////////////////////////////////
 //

--- a/fiori/app/common.cds
+++ b/fiori/app/common.cds
@@ -20,11 +20,12 @@ annotate my.Books with @(
             currency_code
         ],
         LineItem        : [
-            {Value : ID},
-            {Value : title},
-            {Value : author.ID},
             {
-                Value : author.name,
+                Value : ID,
+                Label : '{i18n>Title}'
+            },
+            {
+                Value : author.ID,
                 Label : '{i18n>Author}'
             },
             {Value : genre.name},
@@ -37,7 +38,11 @@ annotate my.Books with @(
         ]
     }
 ) {
-    title  @Common.SemanticObject : 'Books';
+    ID  @Common: {
+        SemanticObject : 'Books',
+        Text: title,
+        TextArrangement : #TextOnly
+    };
     author @ValueList.entity      : 'Authors';
 };
 
@@ -138,7 +143,11 @@ annotate my.Authors with @(
         ],
     }
 ) {
-    name @Common.SemanticObject : 'Authors';
+    ID  @Common: {
+        SemanticObject : 'Authors',
+        Text: name,
+        TextArrangement : #TextOnly,
+    };
 };
 
 ////////////////////////////////////////////////////////////////////////////

--- a/fiori/app/common.cds
+++ b/fiori/app/common.cds
@@ -58,7 +58,7 @@ annotate my.Books with @(UI : {HeaderInfo : {
 //	Books Elements
 //
 annotate my.Books with {
-    ID     @title : '{i18n>ID}'  @UI.HiddenFilter;
+    ID     @title : '{i18n>ID}';
     title  @title : '{i18n>Title}';
     genre  @title : '{i18n>Genre}'  @Common               : {
         Text            : genre.name,
@@ -164,7 +164,7 @@ annotate my.Authors with @(UI : {
 //	Authors Elements
 //
 annotate my.Authors with {
-    ID           @title : '{i18n>ID}'  @UI.HiddenFilter;
+    ID           @title : '{i18n>ID}';
     name         @title : '{i18n>Name}';
     dateOfBirth  @title : '{i18n>DateOfBirth}';
     dateOfDeath  @title : '{i18n>DateOfDeath}';

--- a/fiori/app/common.cds
+++ b/fiori/app/common.cds
@@ -135,7 +135,6 @@ annotate my.Authors with @(
         SelectionFields : [name],
         LineItem        : [
             {Value : ID},
-            {Value : name},
             {Value : dateOfBirth},
             {Value : dateOfDeath},
             {Value : placeOfBirth},

--- a/fiori/app/common.cds
+++ b/fiori/app/common.cds
@@ -22,6 +22,7 @@ annotate my.Books with @(
         LineItem        : [
             {Value : ID},
             {Value : title},
+            {Value : author.ID},
             {
                 Value : author.name,
                 Label : '{i18n>Author}'

--- a/fiori/app/fiori-apps.html
+++ b/fiori/app/fiori-apps.html
@@ -10,32 +10,7 @@
 	<script>
 		window["sap-ushell-config"] = {
 			defaultRenderer: "fiori2",
-			applications: {
-				"browse-books": {
-					title: "Browse Books",
-					description: "w/ SAP Fiori Elements",
-					additionalInformation: "SAPUI5.Component=bookshop",
-					applicationType : "URL",
-					url: "/browse/webapp",
-					navigationMode: "embedded"
-				},
-				"manage-books": {
-					title: "Manage Books",
-					description: "w/ SAP Fiori Elements",
-					additionalInformation: "SAPUI5.Component=admin",
-					applicationType : "URL",
-					url: "/admin/webapp",
-					navigationMode: "embedded"
-				},
-				"manage-orders": {
-					title: "Manage Orders",
-					description: "w/ SAP Fiori Elements",
-					additionalInformation: "SAPUI5.Component=orders",
-					applicationType : "URL",
-					url: "/orders/webapp",
-					navigationMode: "embedded"
-				}
-			}
+			applications: {}
 		};
 	</script>
 

--- a/fiori/app/services.cds
+++ b/fiori/app/services.cds
@@ -4,6 +4,6 @@
 
 using from './admin/fiori-service';
 using from './browse/fiori-service';
+using from './authors/fiori-service';
 using from './common';
-
 using from '@capire/bookstore/srv/mashup';

--- a/test/localized-data.test.js
+++ b/test/localized-data.test.js
@@ -11,39 +11,39 @@ describe('Localized Data', () => {
   })
 
   it('supports sap-language param', async () => {
-    const { data } = await GET(`/browse/Books?$select=title,author` + '&sap-language=de')
+    const { data } = await GET(`/browse/Books?$select=title,authorName` + '&sap-language=de')
     expect(data.value).to.containSubset([
-      { title: 'Sturmhöhe', author: 'Emily Brontë' },
-      { title: 'Jane Eyre', author: 'Charlotte Brontë' },
-      { title: 'The Raven', author: 'Edgar Allen Poe' },
-      { title: 'Eleonora', author: 'Edgar Allen Poe' },
-      { title: 'Catweazle', author: 'Richard Carpenter' },
+      { title: 'Sturmhöhe', authorName: 'Emily Brontë' },
+      { title: 'Jane Eyre', authorName: 'Charlotte Brontë' },
+      { title: 'The Raven', authorName: 'Edgar Allen Poe' },
+      { title: 'Eleonora', authorName: 'Edgar Allen Poe' },
+      { title: 'Catweazle', authorName: 'Richard Carpenter' },
     ])
   })
 
   it('supports accept-language header', async () => {
-    const { data } = await GET(`/browse/Books?$select=title,author`, {
+    const { data } = await GET(`/browse/Books?$select=title,authorName`, {
       headers: { 'Accept-Language': 'de' },
     })
     expect(data.value).to.containSubset([
-      { title: 'Sturmhöhe', author: 'Emily Brontë' },
-      { title: 'Jane Eyre', author: 'Charlotte Brontë' },
-      { title: 'The Raven', author: 'Edgar Allen Poe' },
-      { title: 'Eleonora', author: 'Edgar Allen Poe' },
-      { title: 'Catweazle', author: 'Richard Carpenter' },
+      { title: 'Sturmhöhe', authorName: 'Emily Brontë' },
+      { title: 'Jane Eyre', authorName: 'Charlotte Brontë' },
+      { title: 'The Raven', authorName: 'Edgar Allen Poe' },
+      { title: 'Eleonora', authorName: 'Edgar Allen Poe' },
+      { title: 'Catweazle', authorName: 'Richard Carpenter' },
     ])
   })
 
   it('supports queries with $expand', async () => {
-    const { data } = await GET(`/browse/Books?&$select=title,author&$expand=currency`, {
+    const { data } = await GET(`/browse/Books?&$select=title,authorName&$expand=currency`, {
       headers: { 'Accept-Language': 'de' },
     })
     expect(data.value).to.containSubset([
-      { title: 'Sturmhöhe', author: 'Emily Brontë', currency: { name: 'Pfund' } },
-      { title: 'Jane Eyre', author: 'Charlotte Brontë', currency: { name: 'Pfund' } },
-      { title: 'The Raven', author: 'Edgar Allen Poe', currency: { name: 'US-Dollar' } },
-      { title: 'Eleonora', author: 'Edgar Allen Poe', currency: { name: 'US-Dollar' } },
-      { title: 'Catweazle', author: 'Richard Carpenter', currency: { name: 'Yen' } },
+      { title: 'Sturmhöhe', authorName: 'Emily Brontë', currency: { name: 'Pfund' } },
+      { title: 'Jane Eyre', authorName: 'Charlotte Brontë', currency: { name: 'Pfund' } },
+      { title: 'The Raven', authorName: 'Edgar Allen Poe', currency: { name: 'US-Dollar' } },
+      { title: 'Eleonora', authorName: 'Edgar Allen Poe', currency: { name: 'US-Dollar' } },
+      { title: 'Catweazle', authorName: 'Richard Carpenter', currency: { name: 'Yen' } },
     ])
   })
 

--- a/test/odata.test.js
+++ b/test/odata.test.js
@@ -19,13 +19,13 @@ describe('OData Protocol', () => {
 
   it('supports $search in multiple fields', async () => {
     const { data } = await GET `/browse/Books ${{
-      params: { $search: 'Po', $select: `title,author` },
+      params: { $search: 'Po', $select: `title,authorName` },
     }}`
     expect(data.value).to.eql([
-      { ID: 201, title: 'Wuthering Heights', author: 'Emily Brontë' },
-      { ID: 207, title: 'Jane Eyre', author: 'Charlotte Brontë' },
-      { ID: 251, title: 'The Raven', author: 'Edgar Allen Poe' },
-      { ID: 252, title: 'Eleonora', author: 'Edgar Allen Poe' },
+      { ID: 201, title: 'Wuthering Heights', authorName: 'Emily Brontë' },
+      { ID: 207, title: 'Jane Eyre', authorName: 'Charlotte Brontë' },
+      { ID: 251, title: 'The Raven', authorName: 'Edgar Allen Poe' },
+      { ID: 252, title: 'Eleonora', authorName: 'Edgar Allen Poe' },
     ])
   })
 


### PR DESCRIPTION
Please give it a try with:

`cds watch fiori`

You can browse the Authors and navigate to Books with this link selection pop-up:

<img width="660" alt="Screenshot 2021-11-13 at 01 05 12" src="https://user-images.githubusercontent.com/2639535/141597168-9733c827-56b7-4ad1-b5c7-d44d3dff279d.png">

And from Books you can navigate to Authors:

<img width="572" alt="Screenshot 2021-11-13 at 01 05 29" src="https://user-images.githubusercontent.com/2639535/141597193-1aa2f1f1-a12d-4010-a08e-ac94a7f06332.png">

Let me know if you need any further details. I've used the VS Code CDS Plugin for automatic formatting.
