### PR TITLE
Use cds.requires.auth.kind instead of cds.requires.auth.strategy

### DIFF
--- a/fiori/package.json
+++ b/fiori/package.json
@@ -14,7 +14,7 @@
   "cds": {
     "requires": {
       "auth": {
-        "strategy": "dummy"
+        "kind": "dummy-auth"
       },
       "ReviewsService": {
         "kind": "odata",


### PR DESCRIPTION
As recently discussed, this is the preferred version as opposed to the legacy `cds.requires.auth.strategy`.

@chgeo, can you give me write access to this repository? :)