### PR TITLE
adds @sap/cds dependency to package.json

### DIFF
--- a/hello/package.json
+++ b/hello/package.json
@@ -7,7 +7,7 @@
     "start:ts": "cds-ts serve srv/world.cds"
   },
   "dependencies": {
-    "@sap/cds": "^5.0.4",
+    "@sap/cds": "^5.0.4"
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",

--- a/hello/package.json
+++ b/hello/package.json
@@ -6,6 +6,9 @@
     "start": "cds serve srv/world.cds",
     "start:ts": "cds-ts serve srv/world.cds"
   },
+  "dependencies": {
+    "@sap/cds": "^5.0.4",
+  },
   "devDependencies": {
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.6",


### PR DESCRIPTION
To avoid further questions (e.g. https://answers.sap.com/questions/13577720/i-push-my-capnodejsto-btp-environment-but-always-c.html) this PR will add missing `@sap/cds` dependency.