### PR TITLE
Relative Fiori dataSource URLs

### DIFF
--- a/fiori/app/admin-authors/webapp/manifest.json
+++ b/fiori/app/admin-authors/webapp/manifest.json
@@ -11,7 +11,7 @@
     },
     "dataSources": {
       "AdminService": {
-        "uri": "/admin/",
+        "uri": "admin/",
         "type": "OData",
         "settings": {
           "odataVersion": "4.0"

--- a/fiori/app/admin-books/webapp/manifest.json
+++ b/fiori/app/admin-books/webapp/manifest.json
@@ -8,7 +8,7 @@
         "i18n": "i18n/i18n.properties",
         "dataSources": {
             "AdminService": {
-                "uri": "/admin/",
+                "uri": "admin/",
                 "type": "OData",
                 "settings": {
                     "odataVersion": "4.0"

--- a/fiori/app/browse/webapp/manifest.json
+++ b/fiori/app/browse/webapp/manifest.json
@@ -11,7 +11,7 @@
     },
     "dataSources": {
       "CatalogService": {
-        "uri": "/browse/",
+        "uri": "browse/",
         "type": "OData",
         "settings": {
           "odataVersion": "4.0"
@@ -32,7 +32,7 @@
                 "renameTo": "ID"
               },
               "Authors.books.ID": {
-                "renameTo": "ID"                    
+                "renameTo": "ID"
               }
             },
             "additionalParameters": "ignored"


### PR DESCRIPTION
Since this is what 'real' Fiori apps use as well, to allow serving from
FLP.  CDS's fiori helper takes care that they work w/o FLP as well.