### PR TITLE
Registry to handle packages with dashes

### DIFF
--- a/.registry/server.js
+++ b/.registry/server.js
@@ -16,7 +16,8 @@ app.use('/-/:tarball', (req,res,next) => {
   console.debug ('GET', req.params)
   try {
     const { tarball } = req.params
-    const [, pkg ] = /^\w+-(\w+)/.exec(tarball)
+    const pkgFull = tarball.substring(0, tarball.lastIndexOf('-'))
+    const [, pkg ] = /^\w+-(.+)/.exec(pkgFull)
     fs.lstat(tarball,(err => {
       if (err) console.debug (`npm pack ../${pkg}`)
       if (err) exec(`npm pack ../${pkg}`,{cwd},next)
@@ -31,7 +32,7 @@ app.use('/-/:tarball', (req,res,next) => {
 app.use('/-', express.static(__dirname))
 
 app.get('/*', (req,res)=>{
-  const urlRegex = /^\/(@\w+)\/(\w+)/
+  const urlRegex = /^\/(@[\w-]+)\/(.+)/
   const url = decodeURIComponent(req.url)
   console.debug ('GET',url)
   try {

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -20,7 +20,7 @@ describe('Local NPM registry', () => {
 
   after(() => { registry.kill() })
 
-  for (const mod of ['bookshop','fiori','orders','reviews']) {
+  for (const mod of ['bookshop', 'data-viewer', 'fiori','orders','reviews']) {
     it(`should serve ${mod}`, async () => {
       const resp = await axios.get(`/@capire/${mod}`)
       expect(resp.data).to.containSubset({name: `@capire/${mod}`, versions:{}})


### PR DESCRIPTION
Like `@capire/data-viewer`, resulting in requests like
`GET /capire-data-viewer-0.1.0.tgz`