### PR TITLE
fix Capire URL for Fiori

### DIFF
--- a/.tours/samples.tour
+++ b/.tours/samples.tour
@@ -104,7 +104,7 @@
     },
     {
       "file": "fiori/app/services.cds",
-      "description": "### Annotations for SAP Fiori Elements\n\n- [Adds an SAP Fiori elements application](https://cap.cloud.sap/docs/guides/fiori/) to bookstore, thereby introducing to:\n- [OData Annotations](https://cap.cloud.sap/docs/guides/fiori#adding-odata-annotations) in `.cds` files\n- Support for [Fiori Draft](https://cap.cloud.sap/docs/guides/fiori#draft)\n- Support for [Value Helps](https://cap.cloud.sap/docs/guides/fiori#value-help)\n- Serving SAP Fiori apps locally\n",
+      "description": "### Annotations for SAP Fiori Elements\n\nAdds an SAP Fiori elements application to bookstore, thereby introducing:\n- OData Annotations in `.cds` files\n- Support for Fiori Draft\n- Support for Value Helps\n- Serving SAP Fiori apps locally\n\nSee the [Serving Fiori UIs](https://cap.cloud.sap/docs/advanced/fiori) documentation for more information.",
       "line": 1,
       "selection": {
         "start": {


### PR DESCRIPTION
The URL for the Fiori UI area of Capire is now in the 'advanced' section, so I fixed the URL. I took the opportunity for some minor improvements to the tour text so that there's only a single URL and now the bullet points look cleaner too:

<img width="638" alt="screenshot 2022-07-04 at 15 47 56" src="https://user-images.githubusercontent.com/73068/177178329-f003a9a0-d372-4afc-97f6-1ad59afab133.png">
