### PR TITLE
Fix tests to run with mocha

### DIFF
--- a/test/cds.ql.test.js
+++ b/test/cds.ql.test.js
@@ -1,20 +1,18 @@
-const cds = require('@sap/cds/lib')
-const { expect } = cds.test
-const { cdr } = cds.ql
-const Foo = { name: 'Foo' }
-const Books = { name: 'capire.bookshop.Books' }
-
-
-const STAR = cdr ? '*' : { ref: ['*'] }
-const skip = {to:{eql:()=>skip}}
-const srv = new cds.Service
-let cqn
-
-expect.plain = (cqn) => !cqn.SELECT.one && !cqn.SELECT.distinct ? expect(cqn) : skip
-expect.one = (cqn) => !cqn.SELECT.distinct ? expect(cqn) : skip
-
 describe('cds.ql → cqn', () => {
-  //
+
+  const cds = require('@sap/cds/lib')
+  const { expect } = cds.test
+  const { cdr } = cds.ql
+  const Foo = { name: 'Foo' }
+  const Books = { name: 'capire.bookshop.Books' }
+
+  const STAR = cdr ? '*' : { ref: ['*'] }
+  const skip = {to:{eql:()=>skip}}
+  const srv = new cds.Service
+  let cqn
+
+  expect.plain = (cqn) => !cqn.SELECT.one && !cqn.SELECT.distinct ? expect(cqn) : skip
+  expect.one = (cqn) => !cqn.SELECT.distinct ? expect(cqn) : skip
 
   describe.each(['SELECT', 'SELECT one', 'SELECT distinct'])(`%s...`, (each) => {
 

--- a/test/consuming-services.test.js
+++ b/test/consuming-services.test.js
@@ -1,8 +1,9 @@
 const cds = require('@sap/cds/lib')
-const { expect } = cds.test ('@capire/bookshop')
 
 describe('cap/samples - Consuming Services locally', () => {
-  //
+
+  const { expect } = cds.test ('@capire/bookshop')
+
   it('bootstrapped the database successfully', ()=>{
     const { AdminService } = cds.services
     const { Authors } = AdminService.entities

--- a/test/custom-handlers.test.js
+++ b/test/custom-handlers.test.js
@@ -1,9 +1,10 @@
 const cds = require('@sap/cds/lib')
-const { GET, POST, expect } = cds.test(__dirname+'/../bookshop')
-if (cds.User.default) cds.User.default = cds.User.Privileged // hard core monkey patch
-else cds.User = cds.User.Privileged // hard core monkey patch for older cds releases
 
 describe('cap/samples - Custom Handlers', () => {
+
+  const { GET, POST, expect } = cds.test(__dirname+'/../bookshop')
+  if (cds.User.default) cds.User.default = cds.User.Privileged // hard core monkey patch
+  else cds.User = cds.User.Privileged // hard core monkey patch for older cds releases
 
   it('should reject out-of-stock orders', async () => {
     await POST `/browse/submitOrder ${{ book: 201, quantity: 5 }}`

--- a/test/fiori.test.js
+++ b/test/fiori.test.js
@@ -1,8 +1,9 @@
 const cds = require('@sap/cds/lib')
-const { GET, expect, axios } = cds.test ('@capire/fiori', '--with-mocks')
-axios.defaults.auth = { username: 'alice', password: 'admin' }
 
 describe('cap/samples - Fiori APIs - v2', () => {
+
+  const { GET, expect, axios } = cds.test ('@capire/fiori', '--with-mocks')
+  axios.defaults.auth = { username: 'alice', password: 'admin' }
 
   it('serves $metadata documents in v2', async () => {
     const { headers, data } = await GET `/v2/browse/$metadata`

--- a/test/hello-world.test.js
+++ b/test/hello-world.test.js
@@ -1,7 +1,8 @@
 const cds = require('@sap/cds/lib')
-const { GET, expect } = cds.test (__dirname+'/../hello')
 
 describe('cap/samples - Hello world!', () => {
+
+  const { GET, expect } = cds.test (__dirname+'/../hello')
 
   it('should say hello with class impl', async () => {
     const {data} = await GET `/say/hello(to='world')`

--- a/test/hierarchical-data.test.js
+++ b/test/hierarchical-data.test.js
@@ -1,19 +1,17 @@
 const cds = require('@sap/cds/lib')
-const {expect} = cds.test
-
-// should become cds.compile(...) when cds5 is released
-const model = cds.compile.to.csn (`
-  entity Categories {
-    key ID   : Integer;
-    name     : String;
-    children : Composition of many Categories on children.parent = $self;
-    parent   : Association to Categories;
-  }
-`)
-const {Categories:Cats} = model.definitions
-
 
 describe('cap/samples - Hierarchical Data', ()=>{
+
+	const model = CDL`
+		entity Categories {
+			key ID   : Integer;
+			name     : String;
+			children : Composition of many Categories on children.parent = $self;
+			parent   : Association to Categories;
+		}
+	`
+	const {Categories:Cats} = model.definitions
+	const {expect} = cds.test
 
 	before ('bootstrap sqlite in-memory db...', async()=>{
 		await cds.deploy (model) .to ('sqlite::memory:')

--- a/test/localized-data/services.test.js
+++ b/test/localized-data/services.test.js
@@ -1,8 +1,8 @@
-const { GET, expect, cds } = require('@sap/cds/lib').test (__dirname)
-if (cds.User.default) cds.User.default = cds.User.Privileged // hard core monkey patch
-else cds.User = cds.User.Privileged // hard core monkey patch for older cds releases
-
 describe('cap/samples - Localized Data', () => {
+
+  const { GET, expect, cds } = require('@sap/cds/lib').test (__dirname)
+  if (cds.User.default) cds.User.default = cds.User.Privileged // hard core monkey patch
+  else cds.User = cds.User.Privileged // hard core monkey patch for older cds releases
 
   it('serves localized $metadata documents', async () => {
     const { data } = await GET`/browse/$metadata?sap-language=de`

--- a/test/messaging.test.js
+++ b/test/messaging.test.js
@@ -1,13 +1,13 @@
 const cds = require('@sap/cds/lib')
 const {resolve} = require('path')
-const { expect } = cds.test
-const _model = '@capire/reviews'
-if (cds.User.default) cds.User.default = cds.User.Privileged // hard core monkey patch
-else cds.User = cds.User.Privileged // hard core monkey patch for older cds releases
-
-const Reviews = 'sap.capire.reviews.Reviews'
 
 describe('cap/samples - Messaging', ()=>{
+
+    const { expect } = cds.test
+    const _model = '@capire/reviews'
+    const Reviews = 'sap.capire.reviews.Reviews'
+    if (cds.User.default) cds.User.default = cds.User.Privileged // hard core monkey patch
+    else cds.User = cds.User.Privileged // hard core monkey patch for older cds releases
 
     beforeAll(() => { cds.root = resolve(__dirname, '..') })
     afterAll(() => { cds.root = process.cwd() })

--- a/test/odata.test.js
+++ b/test/odata.test.js
@@ -1,8 +1,8 @@
 const cds = require('@sap/cds/lib')
-const { GET, expect, axios } = cds.test ('@capire/bookshop')
-axios.defaults.auth = { username: 'alice', password: 'admin' }
 
 describe('cap/samples - Bookshop APIs', () => {
+  const { GET, expect, axios } = cds.test ('@capire/bookshop')
+  axios.defaults.auth = { username: 'alice', password: 'admin' }
 
   // Genres
   const Drama = {

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -1,12 +1,14 @@
 
 const cds = require('@sap/cds/lib')
-const { expect } = cds.test
 const { fork } = require('child_process')
 const { resolve } = require('path')
 const verbose = process.env.CDS_TEST_VERBOSE
-// ||true
 
 describe('cap/samples - Local NPM registry', () => {
+
+  const { expect } = cds.test
+  // ||true
+
   let registry
   let axios
   const cwd = resolve(__dirname, '..')


### PR DESCRIPTION
Mocha handles global `beforeAll` and `afterAll`as text fixtures → they are applied to all subsequent `describe`s, **not only in the current file, but in all subsequent files** → we need to pull in invocations of `cds.test()` into top-level `describe`s. 