### PR TITLE
Fiori app *Manage Authors*: Add column labels for `age` and `lifetime`

### DIFF
--- a/fiori/app/_i18n/i18n.properties
+++ b/fiori/app/_i18n/i18n.properties
@@ -12,6 +12,7 @@ DateOfDeath = Date of Death
 PlaceOfBirth = Place of Birth
 PlaceOfDeath = Place of Death
 Age = Age
+Lifetime = Lifetime
 Authors = Authors
 Order = Order
 Orders = Orders

--- a/fiori/app/admin-authors/fiori-service.cds
+++ b/fiori/app/admin-authors/fiori-service.cds
@@ -43,5 +43,10 @@ extend sap.capire.bookshop.Authors with {
   virtual lifetime : String;
 }
 
+annotate AdminService.Authors with {
+  age      @Common.Label : '{i18n>Age}';
+  lifetime @Common.Label : '{i18n>Lifetime}'
+}
+
 // Workaround for Fiori popup for asking user to enter a new UUID on Create
 annotate AdminService.Authors with { ID @Core.Computed; }


### PR DESCRIPTION
## Symptom

When I start the Fiori app:

```
git clone https://github.com/SAP-samples/cloud-cap-samples
cd cloud-cap-samples
npm install
cds watch fiori
```

and I log in to http://localhost:4004/fiori-apps.html (with the Chrome browser) with the user `alice`
and I select the tile *Manage Authors* 
then, in the *Authors* table, the column titles are missing for the columns `age` and `lifetime`.

![Screenshot 2022-11-07 at 09 59 55](https://user-images.githubusercontent.com/10234267/200275265-a10bb16b-00fb-4beb-8a0d-f51d48ad8caf.png)

## Solution

This commit adds the missing column titles.

![Screenshot 2022-11-07 at 10 17 07](https://user-images.githubusercontent.com/10234267/200275357-bc0605f1-ad92-4c5c-b432-a3788602fb88.png)

