### PR TITLE
Fiori app *Browse Books*: Add missing column labels

### DIFF
--- a/bookstore/srv/mashup.cds
+++ b/bookstore/srv/mashup.cds
@@ -12,7 +12,11 @@ using { sap.capire.bookshop.Books } from '@capire/bookshop';
 using { ReviewsService.Reviews } from '@capire/reviews';
 extend Books with {
   reviews : Composition of many Reviews on reviews.subject = $self.ID;
+
+  @Common.Label : '{i18n>Rating}'
   rating  : Decimal;
+
+  @Common.Label : '{i18n>NumberOfReviews}'
   numberOfReviews : Integer;
 }
 

--- a/fiori/app/_i18n/i18n.properties
+++ b/fiori/app/_i18n/i18n.properties
@@ -16,6 +16,7 @@ Authors = Authors
 Order = Order
 Orders = Orders
 Price = Price
+Currency = Currency
 Rating = Rating
 NumberOfReviews = Number of Reviews
 

--- a/fiori/app/_i18n/i18n.properties
+++ b/fiori/app/_i18n/i18n.properties
@@ -16,6 +16,8 @@ Authors = Authors
 Order = Order
 Orders = Orders
 Price = Price
+Rating = Rating
+NumberOfReviews = Number of Reviews
 
 Genre = Genre
 Genres = Genres

--- a/fiori/app/_i18n/i18n.properties
+++ b/fiori/app/_i18n/i18n.properties
@@ -7,6 +7,7 @@ AuthorID = Author ID
 Stock = Stock
 Name = Name
 Description = Description
+Image = Image
 AuthorName = Author's Name
 DateOfBirth = Date of Birth
 DateOfDeath = Date of Death

--- a/fiori/app/_i18n/i18n.properties
+++ b/fiori/app/_i18n/i18n.properties
@@ -6,6 +6,7 @@ Author = Author
 AuthorID = Author ID
 Stock = Stock
 Name = Name
+Description = Description
 AuthorName = Author's Name
 DateOfBirth = Date of Birth
 DateOfDeath = Date of Death

--- a/fiori/app/browse/fiori-service.cds
+++ b/fiori/app/browse/fiori-service.cds
@@ -52,9 +52,6 @@ annotate CatalogService.Books with @(UI : {
         },
         {Value : genre.name},
         {Value : price},
-        {
-            Value : currency.symbol,
-            Label : ' '
-        },
+        {Value : currency.symbol},
     ]
 }, );

--- a/fiori/app/common.cds
+++ b/fiori/app/common.cds
@@ -4,6 +4,7 @@
 
 using { sap.capire.bookshop as my } from '@capire/bookstore';
 using { sap.common } from '@capire/common';
+using { sap.common.Currencies } from '@sap/cds/common';
 
 ////////////////////////////////////////////////////////////////////////////
 //
@@ -25,7 +26,7 @@ annotate my.Books with @(
       { Value: genre.name },
       { Value: stock },
       { Value: price },
-      { Value: currency.symbol, Label: ' ' },
+      { Value: currency.symbol },
     ]
   }
 ) {
@@ -36,6 +37,10 @@ annotate my.Books with @(
   };
   author @ValueList.entity      : 'Authors';
 };
+
+annotate Currencies with {
+  symbol @Common.Label : '{i18n>Currency}';
+}
 
 ////////////////////////////////////////////////////////////////////////////
 //

--- a/fiori/app/common.cds
+++ b/fiori/app/common.cds
@@ -66,6 +66,7 @@ annotate my.Books with {
   price  @title: '{i18n>Price}'   @Measures.ISOCurrency : currency_code;
   stock  @title: '{i18n>Stock}';
   descr  @title: '{i18n>Description}'  @UI.MultiLineText;
+  image  @title: '{i18n>Image}';
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/fiori/app/common.cds
+++ b/fiori/app/common.cds
@@ -65,7 +65,7 @@ annotate my.Books with {
   author @title: '{i18n>Author}'  @Common: { Text: author.name, TextArrangement: #TextOnly };
   price  @title: '{i18n>Price}'   @Measures.ISOCurrency : currency_code;
   stock  @title: '{i18n>Stock}';
-  descr  @UI.MultiLineText;
+  descr  @title: '{i18n>Description}'  @UI.MultiLineText;
 }
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Symptom

When I start the Fiori app:

```
git clone https://github.com/SAP-samples/cloud-cap-samples
cd cloud-cap-samples
npm install
cds watch fiori
```

and I log in to http://localhost:4004/fiori-apps.html (with the Chrome browser) with the user `alice`
and I select the tile *Browse Books* 
then, in the *Books* table, the column titles are missing for the columns:
* `currency.symbol`,
* `descr`,
* `image`,
* `numberOfReviews`, and
* `rating`.


![Screenshot 2022-11-07 at 09 51 29](https://user-images.githubusercontent.com/10234267/200296405-e766caeb-7358-4231-a391-32c462bf15fe.png)


## Solution

This commit adds the missing column labels.

![Screenshot 2022-11-07 at 12 12 10](https://user-images.githubusercontent.com/10234267/200296557-a1299df5-d827-4f17-a44b-d7d07663721a.png)