### PR TITLE
Fiori app *Manage Orders*: Hide technical ID's

### DIFF
--- a/orders/app/fiori.cds
+++ b/orders/app/fiori.cds
@@ -65,6 +65,7 @@ annotate OrdersService.Orders with @(
 ) {
 	createdAt @UI.HiddenFilter:false;
 	createdBy @UI.HiddenFilter:false;
+        ID        @UI.Hidden;
 };
 
 

--- a/orders/app/fiori.cds
+++ b/orders/app/fiori.cds
@@ -91,4 +91,7 @@ annotate OrdersService.Orders.Items with @(
 	quantity @(
 		Common.FieldControl: #Mandatory
 	);
+        ID       @UI.Hidden;
+        up_      @UI.Hidden;
+
 };


### PR DESCRIPTION
## Symptom

When I start the Fiori app:

```
git clone https://github.com/SAP-samples/cloud-cap-samples
cd cloud-cap-samples
npm install
cds watch fiori
```

and I open the app *Manage Orders* (with the Chrome browser) as the user `alice` at the URL http://localhost:4004/fiori-apps.html#Orders-manage
and I open the table *Settings* for the *Orders* table
then I can personalize the table so that it displays the field `ID`, which doesn't have a label, and which contains a technical UUID. 

<img width="1027" alt="Screenshot 2022-11-07 at 14 31 54" src="https://user-images.githubusercontent.com/10234267/200326464-f5291223-4f51-43cc-b66e-b74205d10c4c.png">
<img width="1027" alt="Screenshot 2022-11-07 at 14 32 07" src="https://user-images.githubusercontent.com/10234267/200326481-13b45f9c-1fe6-4076-90ac-893affe11295.png">

Moreover, when I open some order details e.g. http://localhost:4004/fiori-apps.html#Orders-manage&/Orders(ID=64e718c9-ff99-47f1-8ca3-950c850777d4,IsActiveEntity=true)

and I open the table *Settings* for the *OrderItems* table
then I can personalize the table so that it displays the fields `ID` and `up__ID`, which don't have a label, and which both contain technical UUID's. 

<img width="1016" alt="Screenshot 2022-11-07 at 14 32 22" src="https://user-images.githubusercontent.com/10234267/200326805-9a5e27cb-8c2f-4d52-879a-3d5c0579bbe0.png">

<img width="1017" alt="Screenshot 2022-11-07 at 14 32 32" src="https://user-images.githubusercontent.com/10234267/200326813-85249954-ec75-459e-a4ea-cf0d6c257fae.png">


I would expect these technical UUID's to be hidden from the end user.

## Solution

This commit hides the extraneous columns containing technical UUID's.

<img width="1028" alt="Screenshot 2022-11-07 at 14 46 03" src="https://user-images.githubusercontent.com/10234267/200325953-7292144e-3d43-40b8-8cdc-0eadf3b25fb8.png">

<img width="1017" alt="Screenshot 2022-11-07 at 14 45 37" src="https://user-images.githubusercontent.com/10234267/200325967-1446db36-2624-4965-83be-2c7e573d7059.png">


