### PR TITLE
Use eslint probe, not validate in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
   },
   "mochaExplorer.debuggerConfig": "Debug Mocha Tests",
   "mochaExplorer.parallel": true,
-  "eslint.validate": [
+  "eslint.probe": [
     "cds",
     "csn",
     "csv",


### PR DESCRIPTION
- Parsing error as see in issue cap/issues#13123
- Occurs only in `dev` setup
- Should use `eslint.probe` instead of `eslint.validate`, since here the **extension stays silent for probed languages if validation fails**
- See [VS Code ESLint settings options](https://github.com/microsoft/vscode-eslint/blob/main/README.md#settings-options)