### PR TITLE
Manage Books: Show Genre as drop-down

### DIFF
--- a/fiori/app/admin-books/fiori-service.cds
+++ b/fiori/app/admin-books/fiori-service.cds
@@ -81,3 +81,6 @@ extend service AdminService {
 
 // Workaround for Fiori popup for asking user to enter a new UUID on Create
 annotate AdminService.Books with { ID @Core.Computed; }
+
+// Show Genre as drop down, not a dialog
+annotate AdminService.Books with { genre @Common.ValueListWithFixedValues; }


### PR DESCRIPTION
In the *Manage Books* app, proposal to display the *Genre* input field as a drop-down (instead of a dialog)

![Genre as drop-down](https://github.com/SAP-samples/cloud-cap-samples/assets/10234267/7d1bb3c6-588e-47fb-b760-cdaad9591dbb)
