### PR TITLE
Manage Books, Manage Authors: Make `title`, `author` and `name` mandatory

### DIFF
--- a/bookshop/db/schema.cds
+++ b/bookshop/db/schema.cds
@@ -3,9 +3,9 @@ namespace sap.capire.bookshop;
 
 entity Books : managed {
   key ID : Integer;
-  title  : localized String(111);
+  @mandatory title  : localized String(111);
   descr  : localized String(1111);
-  author : Association to Authors;
+  @mandatory author : Association to Authors;
   genre  : Association to Genres;
   stock  : Integer;
   price  : Decimal;
@@ -15,7 +15,7 @@ entity Books : managed {
 
 entity Authors : managed {
   key ID : Integer;
-  name   : String(111);
+  @mandatory name   : String(111);
   dateOfBirth  : Date;
   dateOfDeath  : Date;
   placeOfBirth : String;


### PR DESCRIPTION
Suggestion to make the book attributes `title` and `author` mandatory, 
as well as the author attribute `name`,
in order to demonstrate how mandatory fields are rendered in the Fiori UI.

<img width="800" alt="Screenshot 2023-06-05 at 14 43 09" src="https://github.com/SAP-samples/cloud-cap-samples/assets/10234267/b2c3b615-3728-483f-a244-58ba93af7546">
