### PR TITLE
Prepare for new protocol handling

### DIFF
--- a/bookshop/srv/admin-service.cds
+++ b/bookshop/srv/admin-service.cds
@@ -1,5 +1,5 @@
 using { sap.capire.bookshop as my } from '../db/schema';
-service AdminService @(requires:'admin') {
+service AdminService @(requires:'admin', path:'/admin') {
   entity Books as projection on my.Books;
   entity Authors as projection on my.Authors;
 }

--- a/bookshop/srv/user-service.cds
+++ b/bookshop/srv/user-service.cds
@@ -1,7 +1,7 @@
 /**
  * Exposes user information
  */
-service UserService {
+service UserService @(path: '/user') {
   /**
    * The current user
    */

--- a/hello/srv/world.cds
+++ b/hello/srv/world.cds
@@ -1,3 +1,3 @@
-service say {
+service say @(path: '/say') {
   function hello (to:String) returns String;
 }


### PR DESCRIPTION
@sap/cds version 7 will per default include a protocol-specific prefix in the service path. These changes ensure that the sample models will work with both version 7 and 6.