### PR TITLE
refactor/follow capire documentation bets practices

### DIFF
--- a/hello/srv/world.ts
+++ b/hello/srv/world.ts
@@ -1,4 +1,4 @@
-import type { Request } from "@sap/cds/apis/services"
+import { Request } from "@sap/cds"
 
 module.exports = class say {
     hello(req: Request) {


### PR DESCRIPTION
As we plan to use cap node.js with TS, I came across the examples linked [here](https://cap.cloud.sap/docs/node.js/typescript). 
In the part under Type Imports in the TypeScript APIs section, it states how to do it "good". So the current implementation linked from the documentation must be considered an anti-pattern. The example should therefore match the current recommendation.
