### PR TITLE
README: Remove link to outdated "Getting Started" page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Find here a collection of samples for the [SAP Cloud Application Programming Mod
 
 ### Preliminaries
 
-1. Ensure you have the latest LTS version of Node.js installed (see [Getting Started](https://cap.cloud.sap/docs/get-started/))
+1. Ensure you have the latest LTS version of Node.js installed
 2. Install [**@sap/cds-dk**](https://cap.cloud.sap/docs/get-started/) globally:
 
    ```sh


### PR DESCRIPTION
On the README page, 
when I click on the link

> see [Getting Started](https://cap.cloud.sap/docs/get-started/)

then I get the error:

> Page is not released

I checked the page [Getting Started in a Nutshell](https://cap.cloud.sap/docs/get-started/in-a-nutshell) but it doesn't provide information on how to get the latest node LTS version, so I'd suggest removing the link.