### PR TITLE
concrete error message if modules are not found

### DIFF
--- a/bookstore/server.js
+++ b/bookstore/server.js
@@ -5,10 +5,14 @@ cds.once('served', require('./srv/mashup'))
 
 // Add routes to UIs from imported packages
 cds.once('bootstrap',(app)=>{
-  app.serve ('/bookshop') .from ('@capire/bookshop','app/vue')
-  app.serve ('/reviews') .from ('@capire/reviews','app/vue')
-  app.serve ('/orders') .from('@capire/orders','app/orders')
-  app.serve ('/data') .from('@capire/data-viewer','app/viewer')
+  try {
+    app.serve ('/bookshop') .from ('@capire/bookshop','app/vue')
+    app.serve ('/reviews') .from ('@capire/reviews','app/vue')
+    app.serve ('/orders') .from('@capire/orders','app/orders')
+    app.serve ('/data') .from('@capire/data-viewer','app/viewer')
+  } catch {
+      throw new Error('Run "npm ci" to install the required dependencies')
+  }
 })
 
 // Add Swagger UI

--- a/bookstore/server.js
+++ b/bookstore/server.js
@@ -11,7 +11,7 @@ cds.once('bootstrap',(app)=>{
     app.serve ('/orders') .from('@capire/orders','app/orders')
     app.serve ('/data') .from('@capire/data-viewer','app/viewer')
   } catch (err) {
-    if (err.code === 'MODULE_NOT_FOUND') throw new Error('Run "npm ci" to install the required dependencies')
+    if (err.code === 'MODULE_NOT_FOUND') throw new Error('Run "npm ci" to install the required dependencies', { cause: err })
     throw err
   }
 })


### PR DESCRIPTION
Not sure if this is the right approach.
Even though the readme.md  states to run `npm ci ` before `cds w xx` I was asked by several people struggling with the cap samples who get stuck at `Error: Cannot find module '@capire/bookshop/package.json'`

If you are used to cap projects working without npm i and not familiar with the workspace setup, you will run into this issue and don't necessarily understand why.

