### PR TITLE
Fix xs-app.json routes

### DIFF
--- a/app-router/bookshop
+++ b/app-router/bookshop
@@ -1,1 +1,0 @@
-../bookshop/app/vue

--- a/app-router/orders
+++ b/app-router/orders
@@ -1,1 +1,0 @@
-../orders/app/orders

--- a/app-router/resources/bookshop
+++ b/app-router/resources/bookshop
@@ -1,0 +1,1 @@
+../../bookshop/app/vue

--- a/app-router/resources/orders
+++ b/app-router/resources/orders
@@ -1,0 +1,1 @@
+../../orders/app/orders

--- a/app-router/resources/reviews
+++ b/app-router/resources/reviews
@@ -1,0 +1,1 @@
+../../reviews/app/vue

--- a/app-router/reviews
+++ b/app-router/reviews
@@ -1,1 +1,0 @@
-../reviews/app/vue

--- a/app-router/xs-app.json
+++ b/app-router/xs-app.json
@@ -4,7 +4,7 @@
     {
       "source": "^/app/(.*)$",
       "target": "$1",
-      "localDir": ".",
+      "localDir": "resources",
       "cacheControl": "no-cache, no-store, must-revalidate"
     },
     {

--- a/app-router/xs-app.json
+++ b/app-router/xs-app.json
@@ -8,11 +8,6 @@
       "cacheControl": "no-cache, no-store, must-revalidate"
     },
     {
-      "source": "^/appconfig/",
-      "localDir": ".",
-      "cacheControl": "no-cache, no-store, must-revalidate"
-    },
-    {
       "source": "^/admin/(.*)$",
       "target": "/admin/$1",
       "destination": "bookstore-api",
@@ -41,12 +36,6 @@
       "target": "/reviews/$1",
       "destination": "reviews-api",
       "csrfProtection": true
-    },
-    {
-      "source": "^(.*)$",
-      "target": "$1",
-      "localDir": ".",
-      "cacheControl": "no-cache, no-store, must-revalidate"
     }
   ]
 }

--- a/orders/app/orders/index.html
+++ b/orders/app/orders/index.html
@@ -16,7 +16,7 @@
 					description: "CAP Sample App",
 					additionalInformation: "SAPUI5.Component=orders",
 					applicationType : "URL",
-					url: "/orders/webapp",
+					url: "webapp",
 					navigationMode: "embedded"
 				}
 			}


### PR DESCRIPTION
Exposing the full `.` localDir is not recommended as it also exposes backend files like the package.json.
-> Move symlinks to their own folder for static resources.

Make the url for the manage-orders app relative, so that it can also be found e.g. under /app/orders/webapp.
This removes the need for the `^(.*)$` xs-app.json entry. The appconfig entry is also not needed for the current deployment.