### PR TITLE
chore: prep for service restrictions by default

### DIFF
--- a/test/consuming-services.test.js
+++ b/test/consuming-services.test.js
@@ -3,7 +3,7 @@ const { expect } = cds.test ('@capire/bookshop')
 
 describe('cap/samples - Consuming Services locally', () => {
 
-  before(() => (cds.User.default = cds.User.privileged)) // disable auth checks
+  cds.User.default = cds.User.privileged // disable auth checks
 
   it('bootstrapped the database successfully', ()=>{
     const { AdminService } = cds.services

--- a/test/consuming-services.test.js
+++ b/test/consuming-services.test.js
@@ -3,6 +3,8 @@ const { expect } = cds.test ('@capire/bookshop')
 
 describe('cap/samples - Consuming Services locally', () => {
 
+  before(() => (cds.User.default = cds.User.privileged)) // disable auth checks
+
   it('bootstrapped the database successfully', ()=>{
     const { AdminService } = cds.services
     const { Authors } = AdminService.entities

--- a/test/consuming-services.test.js
+++ b/test/consuming-services.test.js
@@ -4,7 +4,6 @@ cds.User.default = cds.User.privileged // disable auth checks
 
 describe('cap/samples - Consuming Services locally', () => {
 
-
   it('bootstrapped the database successfully', ()=>{
     const { AdminService } = cds.services
     const { Authors } = AdminService.entities

--- a/test/consuming-services.test.js
+++ b/test/consuming-services.test.js
@@ -15,15 +15,15 @@ describe('cap/samples - Consuming Services locally', () => {
     const { Authors } = AdminService.entities
     expect (await SELECT.from(Authors))
     // .to.eql(await SELECT.from('Authors'))
-    .to.eql(await AdminService.tx({user: cds.User.privileged}, tx => tx.read(Authors)))
-    .to.eql(await AdminService.tx({user: cds.User.privileged}, tx => tx.read('Authors')))
-    .to.eql(await AdminService.tx({user: cds.User.privileged}, tx => tx.run(SELECT.from(Authors))))
-    .to.eql(await AdminService.tx({user: cds.User.privileged}, tx => tx.run(SELECT.from('Authors'))))
+    .to.eql(await AdminService.read(Authors))
+    .to.eql(await AdminService.read('Authors'))
+    .to.eql(await AdminService.run(SELECT.from(Authors)))
+    .to.eql(await AdminService.run(SELECT.from('Authors')))
   })
 
   it('allows reading from local services using cds.ql', async () => {
     const AdminService = await cds.connect.to('AdminService')
-    const authors = await AdminService.tx({user: cds.User.privileged}, tx => tx.read (`Authors`, a => {
+    const authors = await AdminService.read (`Authors`, a => {
       a.name,
         a.books((b) => {
           b.title,
@@ -31,7 +31,7 @@ describe('cap/samples - Consuming Services locally', () => {
               c.name, c.symbol
             })
         })
-    }).where(`name like`, 'E%'))
+    }).where(`name like`, 'E%')
     expect(authors).to.containSubset([
       {
         name: 'Emily Brontë',
@@ -69,14 +69,13 @@ describe('cap/samples - Consuming Services locally', () => {
     }
     const query1 = SELECT.from(Authors, projection).where(`name like`, 'E%')
     const query2 = cds.read(Authors, projection).where(`name like`, 'E%')
-    // cds.context = {user: cds.User.privileged}
     expect(await cds.run(query1))
     .to.eql(await db.run(query1))
-    .to.eql(await srv.tx({user: cds.User.privileged}, tx => tx.run(query1)))
-    .to.eql(await srv.tx({user: cds.User.privileged}, tx => tx.read(Authors, projection).where(`name like`, 'E%')))
+    .to.eql(await srv.run(query1))
+    .to.eql(await srv.read(Authors, projection).where(`name like`, 'E%'))
     .to.eql(await cds.run(query2))
     .to.eql(await db.run(query2))
-    .to.eql(await srv.tx({user: cds.User.privileged}, tx => tx.run(query2)))
+    .to.eql(await srv.run(query2))
     .to.eql(await db.read(Authors, projection).where(`name like`, 'E%'))
   })
 })

--- a/test/consuming-services.test.js
+++ b/test/consuming-services.test.js
@@ -1,9 +1,9 @@
 const cds = require('@sap/cds')
 const { expect } = cds.test ('@capire/bookshop')
+cds.User.default = cds.User.privileged // disable auth checks
 
 describe('cap/samples - Consuming Services locally', () => {
 
-  cds.User.default = cds.User.privileged // disable auth checks
 
   it('bootstrapped the database successfully', ()=>{
     const { AdminService } = cds.services


### PR DESCRIPTION
alternatively, the restrictions from adminservice have to be disabled.