### PR TITLE
BUGFIX: npm script for test mispelled

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "orders": "cds watch orders",
     "reviews": "cds watch reviews",
     "lint": "npx eslint",
-    "test": "chest",
+    "test": "jest",
     "jest": "npx jest",
     "mocha": "npx mocha",
     "node:test": "node --test",


### PR DESCRIPTION
on npm run test you can see "chest" but it should be "jest"